### PR TITLE
解决province, city, district在初始值为空字符串时初始化问题

### DIFF
--- a/src/region-picker.js
+++ b/src/region-picker.js
@@ -79,6 +79,7 @@ export default {
     },
     // data model: [code, name]
     _searchIndex (items, model, by) {
+      if (!model) return -1
       // by name
       if (by === 1) {
         for (let key in items) {


### PR DESCRIPTION
初始值为空字符串时，select默认选中北京市等是不合理的
